### PR TITLE
Locked down version illuminate/view to below 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/view": "^5.1"
+        "illuminate/view": "^5.1 <5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0|^5.0",


### PR DESCRIPTION
Due to the requirement of php7 from laravel 5.5 onwards, I locked down to max version 5.4.*.
This because unfortunately php7 is not available on a few projects I work on.

Also in the readme, you refer to laravel 5.1, which requires [php 5.5+](https://github.com/laravel/framework/blob/5.1/composer.json#L18). Which was suitable for my projects.

Other solution would be a hard lock to version 5.1.*