### PR TITLE
Changed the recommended usage to include '->render()' so as to avoid c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ use Jenssegers\Blade\Blade;
 
 $blade = new Blade('views', 'cache');
 
-echo $blade->make('homepage', ['name' => 'John Doe']);
+echo $blade->make('homepage', ['name' => 'John Doe'])->render();
 ```
 
 You can also extend Blade using the `directive()` function:


### PR DESCRIPTION
…asting to __toString which was severely curtailing error reporting

see this discussion: https://stackoverflow.com/questions/26534016/laravel-error-method-illuminate-view-view-tostring-must-not-throw-an-excep