### PR TITLE
Fixed wrong call to method share

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -72,7 +72,7 @@ class Blade implements FactoryContract
 
     public function share($key, $value = null)
     {
-        return $this->factory->shared($key, $value);
+        return $this->factory->share($key, $value);
     }
 
     public function composer($views, $callback): array


### PR DESCRIPTION
When calling the method `share`, the wrong method `shared` is called on the Factory. This commit aim to fix that.