### PR TITLE
Support for BladeCompiler::if()

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Contracts\View\View;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
 use Illuminate\View\ViewServiceProvider;
@@ -58,6 +59,11 @@ class Blade implements FactoryContract
     public function directive(string $name, callable $handler)
     {
         $this->compiler->directive($name, $handler);
+    }
+    
+    public function if($name, callable $callback)
+    {
+        $this->compiler->if($name, $callback);
     }
 
     public function exists($view): bool
@@ -120,5 +126,7 @@ class Blade implements FactoryContract
                 'view.compiled' => $cachePath,
             ];
         }, true);
+        
+        Facade::setFacadeApplication($this->container);
     }
 }


### PR DESCRIPTION
Added if() method so it can be used directly from the Blade instance (just like directive(), etc)
The Facade Application has to be set or you will get an `Uncaught RuntimeException: A facade root has not been set` error