### PR TITLE
Support for 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/view": "^5.5|^6.0"
+        "illuminate/view": "^5.5|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",


### PR DESCRIPTION
I added support for illuminate/view version ^7.0. 

The main problem for me is that i'm using other illuminate packages with version 7 but composer conflicts with this package since it doesn't support 7.0 yet.